### PR TITLE
Support PCI/PCIe Net Device

### DIFF
--- a/redfish-finder
+++ b/redfish-finder
@@ -108,6 +108,73 @@ class USBNetDevice(NetDevice):
 		print("redfish-finder: Unable to find usb network device with vendor:product %s:%s" % (hex(self.vendor), hex(self.product)))
 		return False 
 
+######################################################
+# Subclass of NetDevice, parses the dmidecode output
+# to discover interface name for PCI/PCIe type devices
+######################################################
+class PCINetDevice(NetDevice):
+	def __init__(self, dmioutput):
+		super(NetDevice, self).__init__()
+		dmioutput = cursor_consume_next(dmioutput, "VendorID: ")
+		# Strip the 0x off the front of the vendor, device, subsys_vendor and subsys_device ids
+		self.vendor = int((dmioutput.split()[0])[2:], 16)
+		self.device = int((dmioutput.split()[2])[2:], 16)
+		self.subsys_vendor = int((dmioutput.split()[4])[2:], 16)
+		self.subsys_device = int((dmioutput.split()[6])[2:], 16)
+
+		# Now we need to find the corresponding device name in sysfs
+		if self._find_device() == False:
+			raise RuntimeError("Unable to find PCI/PCIe network device")
+
+	def _getname(self, dpath):
+		for root, dirs, files in os.walk(dpath, topdown=False):
+			for d in dirs:
+				try:
+					if d != "net":
+						continue
+					dr = os.listdir(os.path.join(root, d))
+					self.name = dr[0]
+					return True
+				except:
+					continue
+		return False
+
+	def _find_device(self):
+		for root,dirs,files in os.walk("/sys/bus/pci/devices", topdown=False):
+			for d in dirs:
+				try:
+					f = open(os.path.join(root, d, "vendor"))
+					lines = f.readlines()
+					if int(lines[0][0:6],16) != self.vendor:
+						f.close()
+						continue
+					f.close()
+					f = open(os.path.join(root, d, "device"))
+					lines = f.readlines()
+					if int(lines[0][0:6],16) != self.device:
+						f.close()
+						continue
+					f.close()
+					f = open(os.path.join(root, d, "subsystem_vendor"))
+					lines = f.readlines()
+					if int(lines[0][0:6],16) != self.subsys_vendor:
+						f.close()
+						continue
+					f.close()
+					f = open(os.path.join(root, d, "subsystem_device"))
+					lines = f.readlines()
+					if int(lines[0][0:6],16) != self.subsys_device:
+						f.close()
+						continue
+					f.close()
+					# We found a matching vendor, device, subsystem_vendor and
+					# subsystem_device, go find the net directory and get the interface name
+					return self._getname(os.path.join(root, d))
+				except:
+				    continue
+		print("redfish-finder: Unable to find pci/pcie network device with vendor:device %s:%s and subsystem_vendor:subsystem_device %s:%s"
+			% (hex(self.vendor), hex(self.device), hex(self.subsys_vendor), hex(self.subsys_device)))
+		return False
 
 ######################################################
 # Parses out HostConfig information from SMBIOS for use in
@@ -300,6 +367,8 @@ class dmiobject():
 			dtype = cursor.split()[0]
 			if (dtype == "USB"):
 				newdev = USBNetDevice(cursor)
+			elif (dtype == "PCI/PCIe"):
+				newdev = PCINetDevice(cursor)
 
 			if self.device == None:
 				self.device = newdev


### PR DESCRIPTION
Add a PCI/PCIe type device to discover interface name by vendor, device, subsystem vendor and subsystem device id.
Tested on mockup system with below dmidecode output. Fix issue #6 

dmidecode output : 
```
/ # dmidecode -t 42
# dmidecode 3.5
Getting SMBIOS data from sysfs.
SMBIOS 3.3.0 present.

Handle 0x000F, DMI type 42, 122 bytes
Management Controller Host Interface
        Host Interface Type: Network
        Device Type: PCI/PCIe
        VendorID: 0x10ec
        DeviceID: 0x8168
        SubVendorID: 0x7470
        SubDeviceID: 0x3468
        Protocol ID: 04 (Redfish over IP)
                Service UUID: b70e5a79-c6d6-4267-b02e-9108c989e287
                Host IP Assignment Type: Static
                Host IP Address Format: IPv4
                IPv4 Address: 192.168.20.5
                IPv4 Mask: 255.255.255.0
                Redfish Service IP Discovery Type: Static
                Redfish Service IP Address Format: IPv4
                IPv4 Redfish Service Address: 192.168.20.1
                IPv4 Redfish Service Mask: 255.255.255.0
                Redfish Service Port: 443
                Redfish Service Vlan: 0
                Redfish Service Hostname: 192.168.20.1
```