### PR TITLE
Enhance the error log when USB net device not found

### DIFF
--- a/redfish-finder
+++ b/redfish-finder
@@ -69,7 +69,7 @@ class USBNetDevice(NetDevice):
 
 		# Now we need to find the corresponding device name in sysfs
 		if self._find_device() == False:
-			raise RuntimeError("Unable to find USB network device")
+			raise RuntimeError("Unable to find USB network device. The dmidecode tells us that this device exists. Please check if the device is enabled in the firmware.")
 
 	def _getname(self, dpath):
 		for root, dirs, files in os.walk(dpath, topdown=False):


### PR DESCRIPTION
  * Some device, e.g. iRMC of Fujitsu Primergy server, has its own settings for enabling and disabling the redfish interface. Add more detailed and user-friendly information to the error log to remind users to check these areas in order to use this feature.